### PR TITLE
Add frontend for foodItems

### DIFF
--- a/backend/src/routes/barcode.ts
+++ b/backend/src/routes/barcode.ts
@@ -114,8 +114,8 @@ router.post('/', authenticateToken, async (req, res) => {
       percentLeft: 100,
     });
     const response = {
-      ...foodItem,
-      ...foodType,
+      foodItem: foodItem,
+      foodType: foodType,
     };
 
     console.log('FoodItem created:', response);

--- a/backend/src/routes/barcode.ts
+++ b/backend/src/routes/barcode.ts
@@ -113,9 +113,13 @@ router.post('/', authenticateToken, async (req, res) => {
       expirationDate: expirationDate,
       percentLeft: 100,
     });
+    const response = {
+      ...foodItem,
+      ...foodType,
+    };
 
-    console.log('FoodItem created:', foodItem);
-    return res.status(200).json({ success: true, foodType });
+    console.log('FoodItem created:', response);
+    return res.status(200).json({ success: true, response });
   } catch (err: any) {
     console.error('Error handling barcode:', err.message || err);
     return res.status(500).json({ message: 'Internal server error' });

--- a/backend/src/types/foodItem.ts
+++ b/backend/src/types/foodItem.ts
@@ -15,12 +15,10 @@ export const foodItemSchema = z.object({
 
 export type FoodItem = z.infer<typeof foodItemSchema>;
 
-export const createFoodItemSchema = foodItemSchema
-  .omit({
-    _id: true,
-    typeId: true,
-  })
-  .extend(foodTypeSchema.omit({ _id: true }).partial().shape);
+export const createFoodItemSchema = foodItemSchema.omit({
+  _id: true,
+  typeId: true,
+});
 
 export const updateFoodItemSchema = foodItemSchema
   .partial()

--- a/backend/src/util/dates.ts
+++ b/backend/src/util/dates.ts
@@ -1,14 +1,39 @@
+import logger from './logger';
+
+export const parseDate = (input: string, format: string = 'yyyy-mm-dd') => {
+  const parts = input.match(/\d+/g);
+  if (!parts) {
+    throw new Error(`Invalid date input: ${input}`);
+  }
+
+  // Support only known components
+  const fmt: Partial<Record<'yyyy' | 'mm' | 'dd', number>> = {};
+  let i = 0;
+
+  format.replace(/(yyyy|mm|dd)/g, part => {
+    fmt[part as keyof typeof fmt] = i++;
+    return part;
+  });
+
+  // Default missing components
+  const year =
+    fmt.yyyy !== undefined ? Number(parts[fmt.yyyy]) : new Date().getFullYear(); // Current year if missing
+  // NOTE: Months are 0-indexed in JS/TS
+  const month = fmt.mm !== undefined ? Number(parts[fmt.mm]) - 1 : 0; // January if missing
+  const day = fmt.dd !== undefined ? Number(parts[fmt.dd]) : 1; // Default to 1 if missing
+
+  return new Date(year, month, day);
+};
+
 export const dateDiffInDays = (a: Date, b: Date) => {
   const _MS_PER_DAY = 1000 * 60 * 60 * 24;
   // Discard the time and time-zone information.
+  logger.debug(`Date a: ${a}, Date b: ${b}`);
   const utc1 = Date.UTC(a.getFullYear(), a.getMonth(), a.getDate());
   const utc2 = Date.UTC(b.getFullYear(), b.getMonth(), b.getDate());
+  logger.debug(`UTC1: ${utc1}, UTC2: ${utc2}`);
 
-  if (utc2 < utc1) {
-    return undefined;
-  } else {
-    return Math.floor((utc2 - utc1) / _MS_PER_DAY);
-  }
+  return Math.floor((utc2 - utc1) / _MS_PER_DAY);
 };
 
 export const addDaysToDate = (originalDate: Date, daysToAdd: number) => {

--- a/frontend/app/src/main/java/com/cpen321/usermanagement/data/remote/api/BarcodeInterface.kt
+++ b/frontend/app/src/main/java/com/cpen321/usermanagement/data/remote/api/BarcodeInterface.kt
@@ -1,8 +1,6 @@
 package com.cpen321.usermanagement.data.remote.api
 
 import com.cpen321.usermanagement.data.remote.dto.ApiResponse
-import com.cpen321.usermanagement.data.remote.dto.ProductDataDto
-import com.cpen321.usermanagement.data.repository.FoodType
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Header
@@ -12,16 +10,65 @@ data class BarcodeRequest(
     val barcode: String
 )
 
+data class Nutrients(
+    val calories: String?,
+    val energy_kj: String?,
+    val protein: String?,
+    val fat: String?,
+    val saturated_fat: String?,
+    val monounsaturated_fat: String?,
+    val polyunsaturated_fat: String?,
+    val trans_fat: String?,
+    val cholesterol: String?,
+    val carbs: String?,
+    val sugars: String?,
+    val fiber: String?,
+    val salt: String?,
+    val sodium: String?,
+    val calcium: String?,
+    val iron: String?,
+    val magnesium: String?,
+    val potassium: String?,
+    val zinc: String?,
+    val caffeine: String?
+)
+
 data class BarcodeResponse(
     val success: Boolean,
+    val response: BarcodeResultData
+)
+
+data class BarcodeResultData(
+    val foodItem: FoodItem,
     val foodType: FoodType
+)
+
+data class FoodItem(
+    val _id: String,
+    val userId: String,
+    val typeId: String,
+    val expirationDate: String?,
+    val percentLeft: Int
+)
+
+data class FoodType(
+    val _id: String,
+    val name: String?,
+    val brand: String?,
+    val quantity: String?,
+    val ingredients: String?,
+    val image: String?,
+    val expiration_date: String?,
+    val allergens: List<String>?,
+    val nutrients: Nutrients?,
+    val shelfLifeDays: Int?
 )
 
 interface BarcodeInterface {
     @POST("barcode")
     suspend fun sendBarcode(
+        @Header("Authorization") authHeader: String,
         @Body request: BarcodeRequest,
-        @Header("Authorization") authHeader: String
     ): Response<BarcodeResponse>
 }
 

--- a/frontend/app/src/main/java/com/cpen321/usermanagement/data/repository/BarcodeRepository.kt
+++ b/frontend/app/src/main/java/com/cpen321/usermanagement/data/repository/BarcodeRepository.kt
@@ -1,8 +1,9 @@
 // BarcodeRepository.kt
 package com.cpen321.usermanagement.data.repository
 
+import com.cpen321.usermanagement.data.remote.api.BarcodeResultData
 import com.cpen321.usermanagement.data.remote.dto.ProductDataDto
 
 interface BarcodeRepository {
-    suspend fun sendBarcode(barcode: String): Result<FoodType>
+    suspend fun sendBarcode(barcode: String): Result<BarcodeResultData>
 }

--- a/frontend/app/src/main/java/com/cpen321/usermanagement/ui/navigation/Navigation.kt
+++ b/frontend/app/src/main/java/com/cpen321/usermanagement/ui/navigation/Navigation.kt
@@ -23,6 +23,7 @@ object NavRoutes {
     const val SCANNER = "scanner"
     const val RECIPE = "recipe"
     const val TEST_BARCODE = "test_barcode"
+    const val BARCODE_RESULT = "barcode_result"
 }
 
 @Composable
@@ -89,6 +90,7 @@ private fun handleNavigationEvent(
         is NavigationEvent.NavigateToScanner -> navController.navigate(NavRoutes.SCANNER)
         is NavigationEvent.NavigateToTestBarcode -> navController.navigate(NavRoutes.TEST_BARCODE)
         is NavigationEvent.NavigateToRecipe -> navController.navigate(NavRoutes.RECIPE)
+        is NavigationEvent.NavigateToBarcodeResult -> navController.navigate(NavRoutes.BARCODE_RESULT)
         is NavigationEvent.NavigateBack -> navController.popBackStack()
         is NavigationEvent.ClearBackStack -> navController.popBackStack(navController.graph.startDestinationId, false)
         is NavigationEvent.NoNavigation -> { /* do nothing */ }
@@ -129,7 +131,8 @@ private fun AppNavHost(
                 mainViewModel = mainViewModel,
                 onProfileClick = { navigationStateManager.navigateToProfile() },
                 onRecipeClick = { navigationStateManager.navigateToRecipe() },
-                onTestBarcodeClick = { navigationStateManager.navigateToTestBarcode() }
+                onTestBarcodeClick = { navigationStateManager.navigateToTestBarcode() },
+                onBarcodeResultClick = { navigationStateManager.navigateToBarcodeResult() }
             )
         }
 
@@ -175,6 +178,16 @@ private fun AppNavHost(
             TestBarcodeScreen(
                 mainViewModel = mainViewModel,
                 onBackClick = { navigationStateManager.navigateBack() }
+            )
+        }
+
+        composable(NavRoutes.BARCODE_RESULT) {
+            BarcodeResultScreen(
+                mainViewModel = mainViewModel,
+                onBackClick = { 
+                    mainViewModel.clearBarcodeResult()
+                    navigationStateManager.navigateBack() 
+                }
             )
         }
     }

--- a/frontend/app/src/main/java/com/cpen321/usermanagement/ui/navigation/NavigationStateManager.kt
+++ b/frontend/app/src/main/java/com/cpen321/usermanagement/ui/navigation/NavigationStateManager.kt
@@ -18,6 +18,7 @@ sealed class NavigationEvent {
     object NavigateToScanner : NavigationEvent()
     object NavigateToTestBarcode : NavigationEvent()
     object NavigateToRecipe : NavigationEvent()
+    object NavigateToBarcodeResult : NavigationEvent()
     object NavigateBack : NavigationEvent()
     object ClearBackStack : NavigationEvent()
     object NoNavigation : NavigationEvent()
@@ -127,6 +128,11 @@ class NavigationStateManager @Inject constructor() {
     fun navigateToTestBarcode() {
         _navigationEvent.value = NavigationEvent.NavigateToTestBarcode
         _navigationState.value = _navigationState.value.copy(currentRoute = NavRoutes.TEST_BARCODE)
+    }
+
+    fun navigateToBarcodeResult() {
+        _navigationEvent.value = NavigationEvent.NavigateToBarcodeResult
+        _navigationState.value = _navigationState.value.copy(currentRoute = NavRoutes.BARCODE_RESULT)
     }
 
     fun navigateBack() {

--- a/frontend/app/src/main/java/com/cpen321/usermanagement/ui/screens/BarcodeResultScreen.kt
+++ b/frontend/app/src/main/java/com/cpen321/usermanagement/ui/screens/BarcodeResultScreen.kt
@@ -1,0 +1,434 @@
+package com.cpen321.usermanagement.ui.screens
+
+import Icon
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.cpen321.usermanagement.R
+import com.cpen321.usermanagement.data.remote.api.BarcodeResultData
+import com.cpen321.usermanagement.data.remote.api.Nutrients
+import com.cpen321.usermanagement.ui.theme.LocalSpacing
+import com.cpen321.usermanagement.ui.viewmodels.MainViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun BarcodeResultScreen(
+    mainViewModel: MainViewModel,
+    onBackClick: () -> Unit
+) {
+    val uiState by mainViewModel.uiState.collectAsState()
+    val spacing = LocalSpacing.current
+
+    Scaffold(
+        topBar = {
+            BarcodeResultTopBar(onBackClick = onBackClick)
+        }
+    ) { paddingValues ->
+        BarcodeResultContent(
+            paddingValues = paddingValues,
+            barcodeResult = uiState.barcodeResult,
+            errorMessage = uiState.scanError,
+            onRetryScan = { mainViewModel.clearScanError() }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BarcodeResultTopBar(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TopAppBar(
+        modifier = modifier,
+        title = {
+            Text(
+                text = "Barcode Result",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Medium
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = onBackClick) {
+                Icon(name = R.drawable.ic_arrow_back)
+            }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+            titleContentColor = MaterialTheme.colorScheme.onSurface
+        )
+    )
+}
+
+@Composable
+private fun BarcodeResultContent(
+    paddingValues: PaddingValues,
+    barcodeResult: BarcodeResultData?,
+    errorMessage: String?,
+    onRetryScan: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val spacing = LocalSpacing.current
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(paddingValues)
+            .padding(horizontal = spacing.large, vertical = spacing.medium)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(spacing.large),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        when {
+            errorMessage != null -> {
+                ErrorContent(
+                    errorMessage = errorMessage,
+                    onRetryScan = onRetryScan
+                )
+            }
+            barcodeResult != null -> {
+                SuccessContent(barcodeResult = barcodeResult)
+            }
+            else -> {
+                Text(
+                    text = "No barcode result to display",
+                    style = MaterialTheme.typography.bodyLarge,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    errorMessage: String,
+    onRetryScan: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "❌",
+            style = MaterialTheme.typography.displayLarge
+        )
+        
+        Text(
+            text = "Scan Failed",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.error
+        )
+        
+        Text(
+            text = errorMessage,
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        
+        Button(
+            onClick = onRetryScan,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary
+            )
+        ) {
+            Text("Try Again")
+        }
+    }
+}
+
+@Composable
+private fun SuccessContent(
+    barcodeResult: BarcodeResultData,
+    modifier: Modifier = Modifier
+) {
+    val foodItem = barcodeResult.foodItem
+    val foodType = barcodeResult.foodType
+    
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Success indicator
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "✅",
+                style = MaterialTheme.typography.displayMedium
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            Text(
+                text = "Product Added Successfully!",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        // Product Information Card
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            )
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = "Product Information",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+
+                ProductDetailRow(label = "Name", value = foodType.name)
+                ProductDetailRow(label = "Brand", value = foodType.brand)
+                ProductDetailRow(label = "Quantity", value = foodType.quantity)
+                
+                foodType.shelfLifeDays?.let { days ->
+                    ProductDetailRow(
+                        label = "Shelf Life", 
+                        value = "$days days"
+                    )
+                }
+                
+                foodItem.expirationDate?.let { date ->
+                    ProductDetailRow(
+                        label = "Your Item Expiration Date", 
+                        value = formatDate(date)
+                    )
+                }
+                
+                foodType.expiration_date?.let { date ->
+                    ProductDetailRow(
+                        label = "Product Expiration Date", 
+                        value = date
+                    )
+                }
+                
+                ProductDetailRow(
+                    label = "Quantity Left", 
+                    value = "${foodItem.percentLeft}%"
+                )
+            }
+        }
+
+        // Nutritional Information Card
+        foodType.nutrients?.let { nutrients ->
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        text = "Nutritional Information (per 100g)",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+
+                    NutrientGrid(nutrients = nutrients)
+                }
+            }
+        }
+
+        // Ingredients Card
+        foodType.ingredients?.let { ingredients ->
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = "Ingredients",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    
+                    SelectionContainer {
+                        Text(
+                            text = ingredients,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+            }
+        }
+
+        // Allergens Card
+        foodType.allergens?.let { allergens ->
+            if (allergens.isNotEmpty()) {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = "⚠️ Allergens",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                        
+                        SelectionContainer {
+                            Text(
+                                text = allergens.joinToString(", "),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onErrorContainer
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NutrientGrid(
+    nutrients: Nutrients,
+    modifier: Modifier = Modifier
+) {
+    val nutrientPairs = listOf(
+        "Calories" to nutrients.calories,
+        "Energy (kJ)" to nutrients.energy_kj,
+        "Protein" to nutrients.protein,
+        "Fat" to nutrients.fat,
+        "Saturated Fat" to nutrients.saturated_fat,
+        "Trans Fat" to nutrients.trans_fat,
+        "Monounsaturated Fat" to nutrients.monounsaturated_fat,
+        "Polyunsaturated Fat" to nutrients.polyunsaturated_fat,
+        "Cholesterol" to nutrients.cholesterol,
+        "Salt" to nutrients.salt,
+        "Sodium" to nutrients.sodium,
+        "Carbohydrates" to nutrients.carbs,
+        "Fiber" to nutrients.fiber,
+        "Sugars" to nutrients.sugars,
+        "Calcium" to nutrients.calcium,
+        "Iron" to nutrients.iron,
+        "Magnesium" to nutrients.magnesium,
+        "Potassium" to nutrients.potassium,
+        "Zinc" to nutrients.zinc,
+        "Caffeine" to nutrients.caffeine
+    ).filter { it.second != null }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        nutrientPairs.chunked(2).forEach { row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                row.forEach { (label, value) ->
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(
+                            text = label,
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        SelectionContainer {
+                            Text(
+                                text = value ?: "N/A",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                }
+                // Fill remaining space if odd number of items
+                if (row.size == 1) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProductDetailRow(label: String, value: String?, modifier: Modifier = Modifier) {
+    value?.let {
+        SelectionContainer {
+            Column(modifier = modifier.fillMaxWidth()) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+    }
+}
+
+private fun formatDate(dateString: String): String {
+    return try {
+        val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+        val outputFormat = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+        val date = inputFormat.parse(dateString)
+        outputFormat.format(date ?: Date())
+    } catch (e: Exception) {
+        dateString // Return original string if parsing fails
+    }
+}

--- a/frontend/app/src/main/java/com/cpen321/usermanagement/ui/screens/MainScreen.kt
+++ b/frontend/app/src/main/java/com/cpen321/usermanagement/ui/screens/MainScreen.kt
@@ -22,11 +22,19 @@ fun MainScreen(
     mainViewModel: MainViewModel,
     onProfileClick: () -> Unit,
     onRecipeClick: () -> Unit,
-    onTestBarcodeClick: () -> Unit
+    onTestBarcodeClick: () -> Unit,
+    onBarcodeResultClick: () -> Unit
 ) {
     val uiState by mainViewModel.uiState.collectAsState()
     val snackBarHostState = remember { SnackbarHostState() }
     var showScanner by remember { mutableStateOf(false) }
+
+    // Navigate to barcode result screen when a barcode is successfully scanned
+    LaunchedEffect(uiState.barcodeResult) {
+        if (uiState.barcodeResult != null) {
+            onBarcodeResultClick()
+        }
+    }
 
     MainContent(
         uiState = uiState,

--- a/frontend/app/src/main/java/com/cpen321/usermanagement/ui/screens/TestBarcodeScreen.kt
+++ b/frontend/app/src/main/java/com/cpen321/usermanagement/ui/screens/TestBarcodeScreen.kt
@@ -28,9 +28,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import com.cpen321.usermanagement.R
 import com.cpen321.usermanagement.data.remote.dto.ProductDataDto
-import com.cpen321.usermanagement.data.repository.FoodType
+import com.cpen321.usermanagement.data.remote.api.BarcodeResultData
 import com.cpen321.usermanagement.ui.theme.LocalSpacing
 import com.cpen321.usermanagement.ui.viewmodels.MainViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 @Composable
 fun TestBarcodeScreen(
@@ -90,7 +93,7 @@ private fun TestBarcodeTopBar(
 private fun TestBarcodeContent(
     paddingValues: PaddingValues,
     isSending: Boolean,
-    productData: FoodType?,
+    productData: BarcodeResultData?,
     onSendTestBarcode: () -> Unit,
     errorMessage: String?,
     modifier: Modifier = Modifier
@@ -134,42 +137,96 @@ private fun TestBarcodeContent(
         }
 
         productData?.let { data ->
+            val foodItem = data.foodItem
+            val foodType = data.foodType
+            
             Text(
                 text = "Product Details",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold
             )
 
-            ProductDetailRow(label = "Name", value = data.name)
+            ProductDetailRow(label = "Name", value = foodType.name)
+            ProductDetailRow(label = "Brand", value = foodType.brand)
+            ProductDetailRow(label = "Quantity", value = foodType.quantity)
+            ProductDetailRow(label = "Quantity Left", value = "${foodItem.percentLeft}%")
+            
+            foodType.shelfLifeDays?.let { days ->
+                ProductDetailRow(label = "Shelf Life", value = "$days days")
+            }
+            
+            foodItem.expirationDate?.let { date ->
+                ProductDetailRow(
+                    label = "Your Item Expiration Date", 
+                    value = formatDate(date)
+                )
+            }
+            
+            foodType.expiration_date?.let { date ->
+                ProductDetailRow(
+                    label = "Product Expiration Date", 
+                    value = date
+                )
+            }
 
-            data.nutrients?.let { nutrients ->
+            foodType.nutrients?.let { nutrients ->
                 Text(
-                    text = "Nutrients",
+                    text = "Nutrients (per 100g)",
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Medium
                 )
 
-                ProductDetailRow(label = "Calories (kcal/100g)", value = nutrients.calories)
-                ProductDetailRow(label = "Protein (g/100g)", value = nutrients.protein)
-                ProductDetailRow(label = "Fat (g/100g)", value = nutrients.fat)
-                ProductDetailRow(label = "Carbs (g/100g)", value = nutrients.carbohydrates)
-                ProductDetailRow(label = "Sugars (g/100g)", value = nutrients.sugars)
-                ProductDetailRow(label = "Fiber (g/100g)", value = nutrients.fiber)
-                ProductDetailRow(label = "Salt (g/100g)", value = nutrients.salt)
-                ProductDetailRow(label = "Sodium (mg/100g)", value = nutrients.sodium)
-                // Optional: Add other fields like transFat, mono/polyunsaturatedFat, cholesterol
+                ProductDetailRow(label = "Calories (kcal)", value = nutrients.calories)
+                ProductDetailRow(label = "Energy (kJ)", value = nutrients.energy_kj)
+                ProductDetailRow(label = "Protein (g)", value = nutrients.protein)
+                ProductDetailRow(label = "Fat (g)", value = nutrients.fat)
+                ProductDetailRow(label = "Saturated Fat (g)", value = nutrients.saturated_fat)
+                ProductDetailRow(label = "Trans Fat (g)", value = nutrients.trans_fat)
+                ProductDetailRow(label = "Carbohydrates (g)", value = nutrients.carbs)
+                ProductDetailRow(label = "Sugars (g)", value = nutrients.sugars)
+                ProductDetailRow(label = "Fiber (g)", value = nutrients.fiber)
+                ProductDetailRow(label = "Salt (g)", value = nutrients.salt)
+                ProductDetailRow(label = "Sodium (mg)", value = nutrients.sodium)
+                ProductDetailRow(label = "Calcium (mg)", value = nutrients.calcium)
+                ProductDetailRow(label = "Iron (mg)", value = nutrients.iron)
+                ProductDetailRow(label = "Magnesium (mg)", value = nutrients.magnesium)
+                ProductDetailRow(label = "Potassium (mg)", value = nutrients.potassium)
+                ProductDetailRow(label = "Zinc (mg)", value = nutrients.zinc)
+                ProductDetailRow(label = "Caffeine (mg)", value = nutrients.caffeine)
             }
 
+            foodType.ingredients?.let { ingredients ->
+                Text(
+                    text = "Ingredients",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Medium
+                )
+                SelectionContainer {
+                    Text(
+                        text = ingredients,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
 
-//                SelectionContainer {
-//                    Text(
-//                        text = allergens.joinToString(", "),
-//                        style = MaterialTheme.typography.bodyMedium
-//                    )
-//                }
+            foodType.allergens?.let { allergens ->
+                if (allergens.isNotEmpty()) {
+                    Text(
+                        text = "Allergens",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Medium
+                    )
+                    SelectionContainer {
+                        Text(
+                            text = allergens.joinToString(", "),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
             }
         }
     }
+}
 
 @Composable
 private fun ProductDetailRow(label: String, value: String?, modifier: Modifier = Modifier) {
@@ -187,5 +244,16 @@ private fun ProductDetailRow(label: String, value: String?, modifier: Modifier =
                 )
             }
         }
+    }
+}
+
+private fun formatDate(dateString: String): String {
+    return try {
+        val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+        val outputFormat = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+        val date = inputFormat.parse(dateString)
+        outputFormat.format(date ?: Date())
+    } catch (e: Exception) {
+        dateString // Return original string if parsing fails
     }
 }

--- a/frontend/app/src/main/java/com/cpen321/usermanagement/ui/viewmodels/MainViewModel.kt
+++ b/frontend/app/src/main/java/com/cpen321/usermanagement/ui/viewmodels/MainViewModel.kt
@@ -4,10 +4,8 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cpen321.usermanagement.data.remote.dto.MealSummaryDto
-import com.cpen321.usermanagement.data.remote.dto.ProductDataDto
 import com.cpen321.usermanagement.data.remote.api.BarcodeResultData
 import com.cpen321.usermanagement.data.repository.BarcodeRepository
-import com.cpen321.usermanagement.data.repository.FoodType
 import com.cpen321.usermanagement.data.repository.NotificationRepository
 import com.cpen321.usermanagement.data.repository.RecipeRepository
 import dagger.hilt.android.lifecycle.HiltViewModel


### PR DESCRIPTION
Adds a frontend for foodItems. Additionally has some small fixes in the backend:
- Fixes date handling for dates from Open Food Facts as they had a weird format
- Sends botht the foodItem and foodType in the barcode response
